### PR TITLE
Save iconUrl in course record when creating a new course

### DIFF
--- a/src/app/create-course/create-course.component.ts
+++ b/src/app/create-course/create-course.component.ts
@@ -85,12 +85,15 @@ export class CreateCourseComponent implements OnInit {
             url: val.url,
             longDescription: val.longDescription,
             promo: val.promo,
-            categories: [val.category],
-            iconUrl: this.iconUrl
+            categories: [val.category]
         };
 
         newCourse.promoStartAt = Timestamp.fromDate(this.form.value.promoStartAt);
-
+        
+        if (this.iconUrl) {
+          newCourse.iconUrl = this.iconUrl;
+        }
+        
         this.coursesService.createCourse(newCourse, this.courseId)
             .pipe(
                 tap(course => {

--- a/src/app/create-course/create-course.component.ts
+++ b/src/app/create-course/create-course.component.ts
@@ -85,7 +85,8 @@ export class CreateCourseComponent implements OnInit {
             url: val.url,
             longDescription: val.longDescription,
             promo: val.promo,
-            categories: [val.category]
+            categories: [val.category],
+            iconUrl: this.iconUrl
         };
 
         newCourse.promoStartAt = Timestamp.fromDate(this.form.value.promoStartAt);


### PR DESCRIPTION
This seems to be missing to enable the uploaded icon url (if an icon was uploaded) to be displayed later by course.component.  I think this was missing from the video, as well.